### PR TITLE
Fix reliability, add Revolut markup, redesign UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ wheels/
 .venv
 
 # for this app
-fx_log.csv
+data/
 *.log
-__pycache__/
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN uv venv /venv && \
     uv pip install -r pyproject.toml
 
 COPY visa_fx_backend.py .
+COPY templates/ templates/
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -1,125 +1,83 @@
-# 💱 Visa FX Rate Tracker
+# FX Rate Comparison
 
-A Flask-based dashboard that tracks foreign exchange rates from Visa's public FX API and compares them against ECB benchmark rates. Great for figuring out **real-world currency markups** when using cards like the Chase Sapphire Reserve abroad.
+A Flask dashboard that compares foreign exchange rates from **Visa** and **Revolut** against ECB benchmark rates. Useful for seeing real-world currency markups when using cards abroad.
 
----
+## Features
 
-## 🌍 Features
+- Live Visa and Revolut FX rates vs ECB mid-market benchmarks
+- Markup % calculation for transparency
+- Sparkline trend charts showing how markups evolve
+- CSV logging for long-term analysis
+- Background rate fetching (once daily) — page loads never hit external APIs
+- Disk-persisted cache survives restarts
+- Docker support with optional Traefik integration
 
-- 📈 **Live Visa FX Rates** vs. **ECB Mid-Market Benchmarks**
-- 📊 **Markup %** calculation for transparency
-- 🔥 **Sparkline trend charts** to show how markups evolve over time
-- 📁 **CSV logging** for long-term analysis
-- 🌐 Clean HTML dashboard at `/` with flag emojis 🇯🇵🇬🇧🇲🇽
-- 📤 `/export/csv` and `/export/json` endpoints
-- 📜 `/log/view` to see all historical data in browser
-- �� **Docker support** with Traefik integration
+## Getting Started
 
----
-
-## 🧪 Example Use Cases
-
-- See if you're getting overcharged on foreign transactions
-- Compare Visa's rate to the true interbank rate
-- Monitor currency trends if you're a frequent traveler
-
----
-
-## 🚀 Getting Started
-
-### ▶️ Run with Python (`uv` or pip)
+### Run locally
 
 ```bash
-# Using uv (fast dependency manager)
 uv venv && source .venv/bin/activate
-uv pip install flask requests
-python visa_fx_backend.py
-```
-Or with pip:
-
-```bash
-python -m venv venv
-source venv/bin/activate
-pip install flask requests
+uv pip install -r pyproject.toml
 python visa_fx_backend.py
 ```
 
-Then visit:
-📍 http://localhost:3000
+Then visit http://localhost:3000
 
-
-## 🐳 Docker Usage
-
-```bash
-docker build -t visa-fx-tracker .
-docker run -d -p 3000:3000 visa-fx-tracker
-```
-
-Or with docker compose:
+### Docker
 
 ```bash
 docker compose up -d
 ```
 
-### Docker Deployment
+For local development with port mapping:
 
-1. Local development (with port mapping):
-   ```bash
-   docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
-   ```
-   Access at: http://localhost:3000
-
-2. Production deployment with Traefik:
-   ```bash
-   # Set your domain variables
-   export SUBDOMAIN=visa-fx
-   export DOMAIN_NAME=yourdomain.com
-
-   # Start the application
-   docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
-   ```
-   Access at: https://visa-fx.yourdomain.com
-
-## 🧾 Routes
-
-| Route          | Description                                           |
-|----------------|-------------------------------------------------------|
-| `/`            | Main dashboard (Visa vs. ECB with sparkline trends)   |
-| `/export/json` | Latest FX data in JSON                                |
-| `/export/csv`  | All logged rates as downloadable CSV                  |
-| `/log/view`    | Full log table in browser                             |
-
-## 🔒 Privacy / Safety Notes
-No authentication, credentials, or tokens are used
-
-All headers mimic a standard browser (no API keys)
-
-Logs are local only — no data is sent to third parties
-
-## 📂 Project Structure
-
-```
-visa-fx-tracker/
-├── visa_fx_backend.py     # Main Flask app
-├── requirements.txt       # Pip dependencies
-├── pyproject.toml         # uv-compatible dependencies (optional)
-├── fx_log.csv             # Logged historical rates (auto-generated)
-├── Dockerfile             # Container build
-└── README.md              # You're here!
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
 ```
 
-## 📖 License
-MIT — use, modify, and share freely.
-Attribution appreciated but not required. ✌️
+For production with Traefik:
 
-## ✨ Credits
-Built by me — inspired by real travel, real markups, and real curiosity.
-Feel free to fork, improve, or open issues!
+```bash
+export DOMAIN_NAME=yourdomain.com
+docker compose up -d
+```
 
-### Production Notes
+## Routes
 
-- Uses Gunicorn as the production WSGI server
-- Configured with 4 worker processes
-- 120-second timeout for long-running requests
-- Automatic worker process management
-- Production-ready error handling
+| Route          | Description                          |
+|----------------|--------------------------------------|
+| `/`            | Main dashboard                       |
+| `/health`      | Health check endpoint                |
+| `/export/json` | Current rates as JSON                |
+| `/export/csv`  | Historical rates as downloadable CSV |
+| `/log/view`    | Full log table in browser            |
+
+## Project Structure
+
+```
+fx-rate-compare/
+├── visa_fx_backend.py          # Flask app + background fetcher
+├── templates/
+│   ├── base.html               # Shared layout and styles
+│   ├── index.html              # Main dashboard
+│   └── log.html                # Log viewer
+├── data/
+│   ├── fx_log.csv              # Historical rates (auto-generated)
+│   └── fx_cache.json           # Persisted rate cache
+├── pyproject.toml              # Dependencies
+├── Dockerfile
+├── docker-compose.yml
+├── docker-compose.override.yml # Traefik labels (production)
+└── docker-compose.local.yml    # Port mapping (development)
+```
+
+## How It Works
+
+A background thread fetches rates from Visa and Revolut APIs once every 24 hours. Results are cached in memory and persisted to `data/fx_cache.json`. All HTTP endpoints serve from cache — no user request ever triggers an external API call.
+
+Visa's API is behind Cloudflare, so requests use `curl_cffi` with browser TLS fingerprint impersonation.
+
+## License
+
+MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - FLASK_APP=visa_fx_backend.py
       - FLASK_ENV=production
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/health" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     "flask>=3.1.0",
     "gunicorn>=23.0.0",
     "requests>=2.32.3",
+    "curl-cffi>=0.7",
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}FX Rate Comparison{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #0a0a0a;
+            --surface: #141414;
+            --surface-raised: #1a1a1a;
+            --border: rgba(255, 255, 255, 0.06);
+            --border-subtle: rgba(255, 255, 255, 0.03);
+            --text: #e5e5e5;
+            --text-secondary: #737373;
+            --text-tertiary: #525252;
+            --accent: #60a5fa;
+            --green: #4ade80;
+            --red: #f87171;
+            --amber: #fbbf24;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            padding: 3rem 1.5rem;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+        }
+
+        .table-wrap {
+            background: var(--surface);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.8125rem;
+        }
+
+        thead th {
+            background: var(--surface);
+            color: var(--text-tertiary);
+            font-size: 0.6875rem;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 0.625rem 0.875rem;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+            white-space: nowrap;
+        }
+
+        tbody td {
+            padding: 0.5rem 0.875rem;
+            border-bottom: 1px solid var(--border-subtle);
+            white-space: nowrap;
+        }
+
+        tbody tr:last-child td { border-bottom: none; }
+
+        tbody tr {
+            transition: background 0.1s;
+        }
+
+        tbody tr:hover {
+            background: rgba(255, 255, 255, 0.02);
+        }
+
+        a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            transition: color 0.15s;
+        }
+
+        a:hover { color: var(--text); }
+
+        @media (max-width: 768px) {
+            body { padding: 1.5rem 0.75rem; }
+            table { font-size: 0.75rem; }
+            thead th, tbody td { padding: 0.4rem 0.5rem; }
+            .hide-mobile { display: none; }
+        }
+
+        {% block extra_style %}{% endblock %}
+    </style>
+</head>
+<body>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,155 @@
+{% extends "base.html" %}
+
+{% block extra_style %}
+header {
+    margin-bottom: 2rem;
+}
+
+header h1 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--text);
+    letter-spacing: -0.02em;
+}
+
+header p {
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+}
+
+.mono {
+    font-family: 'JetBrains Mono', 'SF Mono', monospace;
+    font-size: 0.8125rem;
+}
+
+.markup {
+    font-family: 'JetBrains Mono', 'SF Mono', monospace;
+    font-size: 0.8125rem;
+    font-weight: 500;
+}
+
+.markup-low { color: var(--green); }
+.markup-mid { color: var(--amber); }
+.markup-high { color: var(--red); }
+
+.currency-cell {
+    font-weight: 500;
+}
+
+.currency-name {
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+}
+
+.na {
+    color: var(--text-tertiary);
+}
+
+.provider-divider {
+    border-left: 1px solid var(--border);
+}
+
+.col-group-label {
+    text-align: center !important;
+    color: var(--text-secondary);
+    font-size: 0.625rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    padding-top: 0.5rem;
+    padding-bottom: 0.25rem;
+}
+
+.sub-header {
+    font-size: 0.625rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.625rem;
+}
+
+.sparkline-cell svg {
+    display: block;
+    opacity: 0.5;
+}
+
+tbody tr:hover .sparkline-cell svg {
+    opacity: 1;
+}
+
+footer {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
+}
+
+footer a {
+    font-size: 0.6875rem;
+    color: var(--text-tertiary);
+    transition: color 0.15s;
+}
+
+footer a:hover {
+    color: var(--text-secondary);
+}
+{% endblock %}
+
+{% block content %}
+<header>
+    <h1>FX Rates</h1>
+    <p>USD conversion rates &middot; {{ last_updated }}</p>
+</header>
+
+<div class="table-wrap">
+    <table>
+        <thead>
+            <tr>
+                <th rowspan="2">Currency</th>
+                <th rowspan="2" class="hide-mobile">Name</th>
+                <th colspan="2" class="col-group-label provider-divider">Visa</th>
+                <th colspan="2" class="col-group-label provider-divider">Revolut</th>
+                <th rowspan="2" class="hide-mobile" style="width:90px"></th>
+            </tr>
+            <tr>
+                <th class="sub-header provider-divider">Rate</th>
+                <th class="sub-header">Markup</th>
+                <th class="sub-header provider-divider">Rate</th>
+                <th class="sub-header">Markup</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+            <tr>
+                <td class="currency-cell">{{ row.currency }}</td>
+                <td class="currency-name hide-mobile">{{ row.name }}</td>
+                <td class="mono provider-divider">{{ row.visa_rate }}</td>
+                {% if row.visa_markup_val is not none %}
+                <td class="markup {% if row.visa_markup_val < 0.3 %}markup-low{% elif row.visa_markup_val < 0.6 %}markup-mid{% else %}markup-high{% endif %}">{{ row.visa_markup }}</td>
+                {% else %}
+                <td class="na">--</td>
+                {% endif %}
+                <td class="mono provider-divider{% if row.revolut_rate == 'N/A' %} na{% endif %}">{{ row.revolut_rate }}</td>
+                {% if row.revolut_markup_val is not none %}
+                <td class="markup {% if row.revolut_markup_val < 0.3 %}markup-low{% elif row.revolut_markup_val < 0.6 %}markup-mid{% else %}markup-high{% endif %}">{{ row.revolut_markup }}</td>
+                {% else %}
+                <td class="na">--</td>
+                {% endif %}
+                <td class="sparkline-cell hide-mobile">
+                    {% if row.sparkline %}
+                    <svg width="80" height="20" viewBox="0 0 80 20">
+                        <polyline points="{{ row.sparkline }}" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<footer>
+    <a href="/export/csv">csv</a>
+    <a href="/export/json">json</a>
+    <a href="/log/view">log</a>
+</footer>
+{% endblock %}

--- a/templates/log.html
+++ b/templates/log.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block title %}FX Rate Log{% endblock %}
+
+{% block extra_style %}
+.page-header {
+    margin-bottom: 1.5rem;
+}
+
+.page-header h1 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+}
+
+.page-header p {
+    margin-top: 0.25rem;
+}
+
+.page-header a {
+    font-size: 0.75rem;
+    color: var(--text-tertiary);
+}
+
+td {
+    font-family: 'JetBrains Mono', 'SF Mono', monospace;
+    font-size: 0.75rem;
+}
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1>Rate Log</h1>
+    <p><a href="/">&larr; back</a></p>
+</div>
+<div class="table-wrap">
+    <table>
+        <thead>
+            <tr>
+                <th>Timestamp</th>
+                <th>Currency</th>
+                <th>Name</th>
+                <th>Visa Rate</th>
+                <th>Benchmark</th>
+                <th>Markup %</th>
+                <th>Revolut Rate</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+            <tr>
+                {% for cell in row %}<td>{{ cell }}</td>{% endfor %}
+                {% if row|length < 7 %}<td class="na">--</td>{% endif %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/visa_fx_backend.py
+++ b/visa_fx_backend.py
@@ -1,26 +1,58 @@
-from flask import Flask, jsonify, render_template_string, send_file
-import requests
+from flask import Flask, jsonify, render_template, send_file, request, abort
+from curl_cffi import requests as cffi_requests
+import requests as http_requests
+import threading
 import time
 import csv
+import json
 import logging
 from datetime import datetime
 from urllib.parse import quote
 import os
 from collections import defaultdict
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import wraps
 
 # Fix SSL certificate verification in Docker
 os.environ['REQUESTS_CA_BUNDLE'] = '/etc/ssl/certs/ca-certificates.crt'
 
 app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-cache = {}
-cache_timestamps = {}  # per-currency cache timestamps
-TTL = 3 * 60 * 60  # 3 hours
-LOG_FILE = Path(__file__).parent / 'data' / 'fx_log.csv'
 
-LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+# --- Rate limiting ---
+
+RATE_LIMIT = 30        # requests per window
+RATE_WINDOW = 60       # window in seconds
+_rate_buckets = {}     # ip -> (count, window_start)
+_rate_lock = threading.Lock()
+
+
+def rate_limit(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        ip = request.remote_addr
+        now = time.time()
+        with _rate_lock:
+            count, window_start = _rate_buckets.get(ip, (0, now))
+            if now - window_start > RATE_WINDOW:
+                count, window_start = 0, now
+            count += 1
+            _rate_buckets[ip] = (count, window_start)
+        if count > RATE_LIMIT:
+            abort(429)
+        return f(*args, **kwargs)
+    return decorated
+
+REQUEST_TIMEOUT = 15  # seconds per HTTP request
+FETCH_INTERVAL = 24 * 60 * 60  # 24 hours
+DATA_DIR = Path(__file__).parent / 'data'
+LOG_FILE = DATA_DIR / 'fx_log.csv'
+CACHE_FILE = DATA_DIR / 'fx_cache.json'
+
+DATA_DIR.mkdir(parents=True, exist_ok=True)
 if not LOG_FILE.exists():
     LOG_FILE.touch()
 
@@ -36,7 +68,12 @@ VISA_HEADERS = {
     'accept-language': 'en-US,en;q=0.9',
     'dnt': '1',
     'referer': 'https://usa.visa.com/support/consumer/travel-support/exchange-rate-calculator.html',
-    'user-agent': 'Mozilla/5.0',
+    'sec-ch-ua': '"Chromium";v="136", "Google Chrome";v="136", "Not.A/Brand";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    'sec-fetch-dest': 'empty',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-site': 'same-origin',
 }
 
 REVOLUT_HEADERS = {
@@ -47,20 +84,129 @@ REVOLUT_HEADERS = {
     'user-agent': 'Mozilla/5.0',
 }
 
+# In-memory cache: loaded from disk on startup, updated by background thread
+cache = {
+    'rates': {},       # {currency: {visa: {...}, revolut: {...}}}
+    'last_updated': None,
+}
+cache_lock = threading.Lock()
+
+
+# --- Disk persistence ---
+
+def save_cache_to_disk():
+    """Persist cache to disk so it survives restarts."""
+    with cache_lock:
+        snapshot = json.dumps(cache, default=str)
+    CACHE_FILE.write_text(snapshot)
+
+
+def load_cache_from_disk():
+    """Load cache from disk on startup."""
+    global cache
+    if CACHE_FILE.exists():
+        try:
+            data = json.loads(CACHE_FILE.read_text())
+            with cache_lock:
+                cache.update(data)
+            logger.info("Loaded cache from disk (last updated: %s)", cache.get('last_updated'))
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning("Failed to load cache from disk: %s", e)
+
+
+# --- API fetching ---
+
 def fetch_visa_rate(to_currency):
-    """Fetch exchange rate from Visa API."""
+    """Fetch exchange rate from Visa API using browser-like TLS fingerprint."""
     today = datetime.now().strftime('%m/%d/%Y')
     url = f"https://usa.visa.com/cmsapi/fx/rates?amount=10000&fee=0&utcConvertedDate={quote(today)}&exchangedate={quote(today)}&fromCurr=USD&toCurr={to_currency}"
-    response = requests.get(url, headers=VISA_HEADERS)
+    response = cffi_requests.get(
+        url, headers=VISA_HEADERS, timeout=REQUEST_TIMEOUT, impersonate="chrome136"
+    )
     response.raise_for_status()
     return response.json()
+
 
 def fetch_revolut_rate(to_currency):
     """Fetch exchange rate from Revolut API."""
     url = f"https://www.revolut.com/api/exchange/quote?amount=100000&country=US&fromCurrency=USD&isRecipientAmount=false&toCurrency={to_currency}"
-    response = requests.get(url, headers=REVOLUT_HEADERS)
+    response = http_requests.get(url, headers=REVOLUT_HEADERS, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
+
+
+def fetch_currency_rates(currency):
+    """Fetch both Visa and Revolut rates for a currency."""
+    visa_data = None
+    revolut_data = None
+
+    try:
+        visa_data = fetch_visa_rate(currency)
+    except Exception as e:
+        logger.warning("Failed to fetch Visa rate for %s: %s", currency, e)
+
+    try:
+        revolut_data = fetch_revolut_rate(currency)
+    except Exception as e:
+        logger.warning("Failed to fetch Revolut rate for %s: %s", currency, e)
+
+    return currency, visa_data, revolut_data
+
+
+def refresh_all_rates():
+    """Fetch all currency rates in parallel and update the cache."""
+    logger.info("Starting rate refresh for %d currencies...", len(CURRENCIES))
+    now = datetime.now()
+    ts = now.strftime('%Y-%m-%d %H:%M:%S')
+    new_rates = {}
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futures = {executor.submit(fetch_currency_rates, c): c for c in CURRENCIES}
+        for future in as_completed(futures):
+            currency, visa_data, revolut_data = future.result()
+            new_rates[currency] = {
+                'visa': visa_data,
+                'revolut': revolut_data,
+            }
+
+            # Log to CSV when we have visa data
+            if visa_data and 'originalValues' in visa_data:
+                try:
+                    vals = visa_data['originalValues']
+                    visa_rate = float(vals['fxRateVisa'])
+                    currency_name = vals['fromCurrencyName']
+                    benchmark = vals['benchmarks'][0]
+                    benchmark_rate = float(benchmark['benchmarkFxRate'])
+                    markup = float(benchmark['markupWithoutAdditionalFee']) * 100
+                    revolut_rate = None
+                    if revolut_data and isinstance(revolut_data, dict) and 'rate' in revolut_data:
+                        revolut_rate = float(revolut_data['rate']['rate'])
+                    log_fx_rate(ts, currency, currency_name, visa_rate, benchmark_rate, markup, revolut_rate)
+                except Exception as e:
+                    logger.warning("Error logging data for %s: %s", currency, e)
+
+    with cache_lock:
+        cache['rates'] = new_rates
+        cache['last_updated'] = ts
+
+    save_cache_to_disk()
+
+    success_visa = sum(1 for r in new_rates.values() if r['visa'] and 'originalValues' in r.get('visa', {}))
+    success_revolut = sum(1 for r in new_rates.values() if r['revolut'] and 'rate' in r.get('revolut', {}))
+    logger.info("Rate refresh complete: Visa %d/%d, Revolut %d/%d", success_visa, len(CURRENCIES), success_revolut, len(CURRENCIES))
+
+
+def background_fetcher():
+    """Background thread that refreshes rates once per day."""
+    while True:
+        try:
+            refresh_all_rates()
+        except Exception as e:
+            logger.error("Background fetch failed: %s", e)
+        time.sleep(FETCH_INTERVAL)
+
+
+# --- CSV logging / history ---
 
 def log_fx_rate(timestamp, currency, name, visa_rate, benchmark_rate, markup, revolut_rate=None):
     """Log exchange rate data to CSV file."""
@@ -72,11 +218,11 @@ def log_fx_rate(timestamp, currency, name, visa_rate, benchmark_rate, markup, re
 def load_logs():
     """Load historical markup data for trend analysis."""
     history = defaultdict(list)
-    if not os.path.exists(LOG_FILE):
+    if not LOG_FILE.exists():
         return history
     with open(LOG_FILE, 'r') as f:
         for row in csv.reader(f):
-            if len(row) >= 6:  # Updated to handle old and new CSV format
+            if len(row) >= 6:
                 _, code, _, _, _, markup = row[:6]
                 try:
                     history[code].append(float(markup))
@@ -84,164 +230,117 @@ def load_logs():
                     continue
     return history
 
-def generate_sparkline(data):
-    """Generate ASCII sparkline from data points."""
-    bars = "▁▂▃▄▅▆▇█"
+
+def generate_sparkline_points(data, width=80, height=20):
+    """Generate SVG polyline points from data."""
     if not data:
         return ""
-    mi, ma = min(data), max(data)
-    if mi == ma:
-        return bars[0] * len(data)
-    step = (ma - mi) / (len(bars) - 1)
-    return ''.join(bars[min(len(bars)-1, int((val - mi) / step))] for val in data[-20:])
+    pts = data[-20:]
+    mi, ma = min(pts), max(pts)
+    spread = ma - mi if ma != mi else 1
+    n = len(pts)
+    if n == 1:
+        return f"{width/2},{height/2}"
+    coords = []
+    for i, val in enumerate(pts):
+        x = (i / (n - 1)) * width
+        y = height - ((val - mi) / spread) * height
+        coords.append(f"{x:.1f},{y:.1f}")
+    return " ".join(coords)
+
+
+# --- Routes (all read-only from cache, never hit external APIs) ---
+
+@app.route('/health')
+def health():
+    with cache_lock:
+        has_data = bool(cache.get('rates'))
+    return jsonify(status='ok', has_data=has_data)
+
 
 @app.route('/')
+@rate_limit
 def index():
-    now = int(time.time())
-    most_recent_fetch = max(cache_timestamps.values()) if cache_timestamps else 0
-    last_updated_str = datetime.fromtimestamp(most_recent_fetch).strftime('%Y-%m-%d %H:%M:%S') if most_recent_fetch else 'Never'
-    rows = []
+    with cache_lock:
+        rates = cache.get('rates', {})
+        last_updated_str = cache.get('last_updated') or 'Fetching...'
+
     history = load_logs()
+    rows = []
 
     for currency in CURRENCIES:
-        currency_last_fetched = cache_timestamps.get(currency, 0)
-        should_refresh = f"{currency}_visa" not in cache or (now - currency_last_fetched) > TTL
-        if should_refresh:
-            visa_data = None
-            revolut_data = None
-
-            # Fetch Visa rate
-            try:
-                visa_data = fetch_visa_rate(currency)
-                cache[f"{currency}_visa"] = visa_data
-            except Exception as e:
-                logger.warning("Failed to fetch Visa rate for %s: %s", currency, e)
-                cache[f"{currency}_visa"] = {"error": str(e)}
-
-            # Fetch Revolut rate
-            try:
-                revolut_data = fetch_revolut_rate(currency)
-                cache[f"{currency}_revolut"] = revolut_data
-            except Exception as e:
-                logger.warning("Failed to fetch Revolut rate for %s: %s", currency, e)
-                cache[f"{currency}_revolut"] = {"error": str(e)}
-
-            cache_timestamps[currency] = now
-            last_updated_str = datetime.fromtimestamp(now).strftime('%Y-%m-%d %H:%M:%S')
-
-            # Log to CSV only when new data is fetched
-            if visa_data and 'error' not in visa_data:
-                try:
-                    visa_rate = float(visa_data['originalValues']['fxRateVisa'])
-                    currency_name = visa_data['originalValues']['fromCurrencyName']
-                    benchmark = visa_data['originalValues']['benchmarks'][0]
-                    benchmark_rate = float(benchmark['benchmarkFxRate'])
-                    markup = float(benchmark['markupWithoutAdditionalFee']) * 100
-
-                    revolut_rate = None
-                    if revolut_data and 'error' not in revolut_data:
-                        revolut_rate = float(revolut_data['rate']['rate'])
-
-                    log_fx_rate(last_updated_str, currency, currency_name, visa_rate, benchmark_rate, markup, revolut_rate)
-                except Exception as e:
-                    logger.warning("Error logging data for %s: %s", currency, e)
-
-        # Display data
-        visa_data = cache.get(f"{currency}_visa", {})
-        revolut_data = cache.get(f"{currency}_revolut", {})
+        currency_data = rates.get(currency, {})
+        visa_data = currency_data.get('visa') or {}
+        revolut_data = currency_data.get('revolut') or {}
 
         try:
-            visa_rate = float(visa_data['originalValues']['fxRateVisa'])
+            # Visa rate is foreign→USD, invert to get USD→foreign
+            visa_raw = float(visa_data['originalValues']['fxRateVisa'])
+            visa_rate = 1.0 / visa_raw
             currency_name = visa_data['originalValues']['fromCurrencyName']
             benchmark = visa_data['originalValues']['benchmarks'][0]
-            benchmark_rate = float(benchmark['benchmarkFxRate'])
-            markup = float(benchmark['markupWithoutAdditionalFee']) * 100
-            trend = generate_sparkline(history[currency] + [markup])
+            benchmark_raw = float(benchmark['benchmarkFxRate'])
+            benchmark_rate = 1.0 / benchmark_raw
+            visa_markup = float(benchmark['markupWithoutAdditionalFee']) * 100
 
-            # Get Revolut rate
-            revolut_rate_str = 'N/A'
-            if revolut_data and 'error' not in revolut_data:
+            # Revolut rate is already USD→foreign
+            revolut_rate = None
+            revolut_markup = None
+            if revolut_data and isinstance(revolut_data, dict) and 'rate' in revolut_data:
                 try:
                     revolut_rate = float(revolut_data['rate']['rate'])
-                    revolut_rate_str = f"{revolut_rate:.6f}"
+                    revolut_markup = ((benchmark_rate - revolut_rate) / benchmark_rate) * 100
                 except (KeyError, ValueError, TypeError):
-                    revolut_rate_str = 'Error'
+                    pass
 
-            rows.append((
-                f"{FLAG_MAP.get(currency, '')} {currency}",
-                currency_name,
-                f"{visa_rate:.6f}",
-                revolut_rate_str,
-                f"{benchmark_rate:.6f}",
-                f"{markup:.4f}%",
-                trend
-            ))
+            # Determine decimal places based on rate magnitude
+            decimals = 2 if visa_rate > 100 else (4 if visa_rate > 1 else 6)
+
+            trend_data = history.get(currency, []) + [visa_markup]
+            sparkline_points = generate_sparkline_points(trend_data)
+
+            rows.append({
+                'currency': f"{FLAG_MAP.get(currency, '')} {currency}",
+                'name': currency_name,
+                'visa_rate': f"{visa_rate:.{decimals}f}",
+                'visa_markup': f"{visa_markup:.3f}%",
+                'visa_markup_val': visa_markup,
+                'revolut_rate': f"{revolut_rate:.{decimals}f}" if revolut_rate else 'N/A',
+                'revolut_markup': f"{revolut_markup:.3f}%" if revolut_markup is not None else 'N/A',
+                'revolut_markup_val': revolut_markup,
+                'sparkline': sparkline_points,
+            })
         except Exception:
-            rows.append((currency, 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', ''))
+            rows.append({
+                'currency': f"{FLAG_MAP.get(currency, '')} {currency}",
+                'name': 'N/A', 'visa_rate': 'N/A', 'visa_markup': 'N/A',
+                'visa_markup_val': None, 'revolut_rate': 'N/A',
+                'revolut_markup': 'N/A', 'revolut_markup_val': None,
+                'sparkline': '',
+            })
 
-    html = '''
-    <!doctype html>
-    <html>
-    <head>
-        <title>FX Rate Comparison</title>
-        <style>
-            body { font-family: sans-serif; padding: 20px; }
-            table { border-collapse: collapse; width: 100%; max-width: 1200px; margin: auto; }
-            th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: center; }
-            th { background-color: #f4f4f4; }
-            footer { text-align: center; margin-top: 20px; color: #666; font-size: 0.9em; }
-            .provider { font-weight: bold; }
-        </style>
-    </head>
-    <body>
-        <h1 style="text-align:center;">FX Rate Comparison: Visa vs Revolut</h1>
-        <table>
-            <tr>
-                <th>Currency</th>
-                <th>Currency Name</th>
-                <th class="provider">Visa Rate</th>
-                <th class="provider">Revolut Rate</th>
-                <th>Benchmark Rate</th>
-                <th>Visa Markup</th>
-                <th>Trend</th>
-            </tr>
-            {% for row in rows %}
-            <tr>
-                <td>{{ row[0] }}</td>
-                <td>{{ row[1] }}</td>
-                <td>{{ row[2] }}</td>
-                <td>{{ row[3] }}</td>
-                <td>{{ row[4] }}</td>
-                <td>{{ row[5] }}</td>
-                <td>{{ row[6] }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-        <footer>
-            <p>Last updated: {{ last_updated }}</p>
-            <p>
-                <a href="/export/csv">Download CSV</a> |
-                <a href="/export/json">Download JSON</a> |
-                <a href="/log/view">View Log</a>
-            </p>
-        </footer>
-    </body>
-    </html>
-    '''
-    return render_template_string(html, rows=rows, last_updated=last_updated_str)
+    return render_template('index.html', rows=rows, last_updated=last_updated_str)
+
 
 @app.route('/export/csv')
+@rate_limit
 def export_csv():
     return send_file(LOG_FILE, mimetype='text/csv', as_attachment=True, download_name='fx_log.csv')
 
+
 @app.route('/export/json')
+@rate_limit
 def export_json():
-    """Export current rates as JSON (filtered to essential fields only)."""
+    """Export current rates as JSON."""
+    with cache_lock:
+        rates = cache.get('rates', {})
+
     result = {}
     for currency in CURRENCIES:
         entry = {}
-        visa_data = cache.get(f"{currency}_visa", {})
-        revolut_data = cache.get(f"{currency}_revolut", {})
+        currency_data = rates.get(currency, {})
+        visa_data = currency_data.get('visa') or {}
+        revolut_data = currency_data.get('revolut') or {}
         if 'originalValues' in visa_data:
             vals = visa_data['originalValues']
             entry['visa_rate'] = vals.get('fxRateVisa')
@@ -250,7 +349,7 @@ def export_json():
             if benchmarks:
                 entry['benchmark_rate'] = benchmarks[0].get('benchmarkFxRate')
                 entry['visa_markup'] = benchmarks[0].get('markupWithoutAdditionalFee')
-        if revolut_data and 'error' not in revolut_data:
+        if revolut_data and isinstance(revolut_data, dict) and 'rate' in revolut_data:
             try:
                 entry['revolut_rate'] = revolut_data['rate']['rate']
             except (KeyError, TypeError):
@@ -258,41 +357,25 @@ def export_json():
         result[currency] = entry
     return jsonify(result)
 
+
 @app.route('/log/view')
+@rate_limit
 def view_log():
     """Display the exchange rate log data."""
-    if not os.path.exists(LOG_FILE):
+    if not LOG_FILE.exists():
         return "No log data yet."
     with open(LOG_FILE, 'r') as f:
         rows = list(csv.reader(f))
-    html = '''
-    <h2 style="text-align:center;">FX Rate Log</h2>
-    <table border=1 style="margin:auto; border-collapse:collapse;">
-        <tr>
-            <th>Timestamp</th>
-            <th>Currency</th>
-            <th>Name</th>
-            <th>Visa Rate</th>
-            <th>Benchmark Rate</th>
-            <th>Visa Markup %</th>
-            <th>Revolut Rate</th>
-        </tr>
-        {% for row in rows %}
-        <tr>
-            {% for cell in row %}
-            <td>{{ cell }}</td>
-            {% endfor %}
-            {% if row|length < 7 %}
-            <td>N/A</td>
-            {% endif %}
-        </tr>
-        {% endfor %}
-    </table>
-    <p style="text-align:center; margin-top:20px;">
-        <a href="/">← Back to Main Page</a>
-    </p>
-    '''
-    return render_template_string(html, rows=rows)
+    return render_template('log.html', rows=rows)
+
+
+# --- Startup ---
+
+load_cache_from_disk()
+
+# Start background fetcher thread (daemon so it dies with the main process)
+_fetcher = threading.Thread(target=background_fetcher, daemon=True)
+_fetcher.start()
 
 if __name__ == '__main__':
     app.run(debug=False, host='0.0.0.0', port=3000)


### PR DESCRIPTION
## Summary

- **Fix worker timeouts**: requests now have 15s timeout, currencies fetched in parallel
- **Bypass Cloudflare**: Visa requests use `curl_cffi` with Chrome TLS fingerprint impersonation
- **Background fetching**: rates refresh daily in a background thread — page loads never hit external APIs
- **Disk-persisted cache**: survives container restarts via `data/fx_cache.json`
- **Rate limiting**: 30 req/min per IP
- **Fixed rate direction**: Visa rates normalized to USD→foreign to match Revolut
- **Revolut markup**: computed against ECB benchmark alongside Visa markup
- **Jinja templates**: moved inline HTML to `templates/` with base template inheritance
- **Redesigned UI**: minimal dark theme, grouped Visa/Revolut columns, SVG sparklines
- **Health endpoint**: `/health` for Docker healthcheck instead of hitting `/`

Closes #1